### PR TITLE
examples: add highlighting of kubectl column headers

### DIFF
--- a/examples/kubectl.yml
+++ b/examples/kubectl.yml
@@ -2,7 +2,7 @@
 # create a directory ~/.cwtch and copy this file into it.
 cmd_regex: kubectl # only apply this configuration if kubectl is found in the command
 highlights:
-  - regex: Running|Active
+  - regex: Running|Active|Ready
     fg: green
 
   - regex: "Pending|Terminating|Available|Init:"
@@ -24,3 +24,10 @@ highlights:
 
   - regex: 0/1
     fg: yellow, bold
+
+  - regex: NotReady
+    fg: bold
+    bg: red
+
+  - regex: NAME|READY|STATUS|RESTARTS|AGE|ROLES|VERSION|IP|NODE|EXTERNAL-IP|OS-IMAGE|KERNEL-VERSION|CONTAINER-RUNTIME|DATA|DESIRED|SUCCESSFUL|TYPE|CLUSTER-IP|PORT\(S\)
+    fg: underline, bold


### PR DESCRIPTION
This adds highlighting for common column headers as found in the output of `kubectl` to the kubectl example by showing them as bold and underlined. In addition, it adds highlighting for the specific states of nodes: `Ready` is now shown as green, whereas `NotReady` is shown in bold with a red background.